### PR TITLE
Corrected wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # iOS
 
 This repository contains code for the native iOS app that displays the [air partners web application](https://github.com/airpartners/aq-web-client) 
-and includes some iOS-specific implementations for features like navigation. As we update the web app, we'll need to ensure that this app continues
-to display the web app as expected and add iOS-specific features (like navigation, notifications, location services, etc.).
+and includes some Android-specific content for releases. As we update the web app, we'll need to ensure that this app continues
+to display the web app as expected and add android-specific features (like notifications, location services, etc.).
 
-For more information about development and deployment, check out the [Getting Started guide in the wiki](https://github.com/airpartners/IOS/wiki/Getting-Started).
+For more information about development and deployment, check out the [IOS app wiki](https://github.com/airpartners/IOS/wiki).


### PR DESCRIPTION
The old IOS wiki was only a single page with a getting started guide; this has been updated to also include a development page. Correct the README such that it only points to the wiki homepage so developers can navigate to a specific page.