### PR TITLE
Added link to feedback page to navigation bar

### DIFF
--- a/EBAirQuality/ViewController.swift
+++ b/EBAirQuality/ViewController.swift
@@ -34,6 +34,7 @@ class ViewController: UIViewController, WKNavigationDelegate {
     "Anna Voy, EB": "SN000-072",
     "FAQ": "faq",
     "Contact us": "contact-us",
+    "Feedback": "feedback",
     "Privacy Policy": "privacy"]
     
     func setupChooseLocationDropDown() {
@@ -49,6 +50,7 @@ class ViewController: UIViewController, WKNavigationDelegate {
             "Anna Voy, EB",
             "FAQ",
             "Contact us",
+	     "Feedback",
             "Privacy Policy"
         ]
         


### PR DESCRIPTION
After adding the feedback page (see [PR](https://github.com/airpartners/aq-web-client/pull/57), we need to add a link to it in the iOS navbar. This PR seeks to do that. I tested this with an iPhone SE on the iOS app simulator in xcode. Will push build as soon as I get an LGTM on this.