### PR TITLE
Made iOS app navbar match web app navbar

### DIFF
--- a/EBAirQuality/ViewController.swift
+++ b/EBAirQuality/ViewController.swift
@@ -26,15 +26,16 @@ class ViewController: UIViewController, WKNavigationDelegate {
     }
 
     
-    let locations = ["St Andrew Road, EB": "SN000-045",
-    "Everett Street, EB": "SN000-046",
-    "Elmer Ave, Winthrop": "SN000-049",
-    "Sumner, EB": "SN000-062",
-    "Bay View Ave, Winthrop": "SN000-067",
-    "Anna Voy, EB": "SN000-072",
-    "FAQ": "faq",
+    let locations = [
+    "Orient Heights, EB": "SN000-045",
+    "Gibson Park, Revere": "SN000-046",
+    "Chelsea Point, Winthrop": "SN000-049",
+    "Jeffries Point, EB": "SN000-062",
+    "Point Shirley, Winthrop": "SN000-067",
+    "Beachmont, Revere": "SN000-114",
     "Contact us": "contact-us",
     "Feedback": "feedback",
+    "FAQ": "faq",
     "Privacy Policy": "privacy"]
     
     func setupChooseLocationDropDown() {
@@ -42,15 +43,15 @@ class ViewController: UIViewController, WKNavigationDelegate {
         chooseLocationDropDown.bottomOffset = CGPoint(x: 0, y: locationButton.bounds.height)
         chooseLocationDropDown.direction = .bottom
         chooseLocationDropDown.dataSource = [
-            "St Andrew Road, EB",
-            "Everett Street, EB",
-            "Elmer Ave, Winthrop",
-            "Sumner, EB",
-            "Bay View Ave, Winthrop",
-            "Anna Voy, EB",
-            "FAQ",
+            "Orient Heights, EB",
+            "Gibson Park, Revere",
+            "Chelsea Point, Winthrop",
+            "Jeffries Point, EB",
+            "Point Shirley, Winthrop",
+            "Beachmont, Revere",
             "Contact us",
 	     "Feedback",
+	     "FAQ",
             "Privacy Policy"
         ]
         

--- a/EBAirQuality/ViewController.swift
+++ b/EBAirQuality/ViewController.swift
@@ -50,8 +50,8 @@ class ViewController: UIViewController, WKNavigationDelegate {
             "Point Shirley, Winthrop",
             "Beachmont, Revere",
             "Contact us",
-	     "Feedback",
-	     "FAQ",
+	    "Feedback",
+	    "FAQ",
             "Privacy Policy"
         ]
         

--- a/EBAirQuality/ViewController.swift
+++ b/EBAirQuality/ViewController.swift
@@ -82,11 +82,12 @@ class ViewController: UIViewController, WKNavigationDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        locationButton.setTitle("St Andrew Road, EB", for: .normal)
+	// TODO: Automatically grab first item in dropdown (see Issue 15)     
+        locationButton.setTitle("Orient Heights, EB", for: .normal)
         webView.navigationDelegate = self
         setupChooseLocationDropDown()
         // TODO: Write function that gets location based on coordinates of person
-        let myURL = URL(string: getURLString(location: "St Andrew Road, EB"))
+        let myURL = URL(string: getURLString(location: "Orient Heights, EB"))
         webView.load(URLRequest(url: myURL!))
     }
 }


### PR DESCRIPTION
I updated the navigation bar in the view controller to match the navigation bar on the web app. If we want to have a larger conversation about the order of the navigation bar elements, we can, but I'd argue that should happen in aq-web-client (and then we'd want to update here) and that it might not be the highest priority at the moment. 

I haven't tested all the links on the simulator yet, but will when I build this.